### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   lint_format:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Cattn/Maple/security/code-scanning/23](https://github.com/Cattn/Maple/security/code-scanning/23)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes needed by the workflow. This can be added either at the top level of the workflow (applies to all jobs) or on the specific job that CodeQL flagged. Since this workflow primarily checks out code, installs Node dependencies, runs format/lint, and then commits and pushes formatting changes, it only needs permission to read and write repository contents; it does not need broader permissions like actions, issues, or pull-requests.

The best fix without changing existing functionality is to add a `permissions` block under the `lint_format` job specifying `contents: write`. This will ensure the job still has enough access to push commits while restricting GITHUB_TOKEN to repository contents only. You could also add `permissions` at the workflow root, but because CodeQL flagged a specific job and this workflow currently has only one job, putting the block under `jobs.lint_format` is straightforward and precise. Concretely, in `.github/workflows/lint-format.yml`, insert a `permissions:` mapping under `lint_format:` (line 9) and above `runs-on:` (line 10), with proper indentation:

```yaml
  lint_format:
    permissions:
      contents: write
    runs-on: ubuntu-latest
```

No additional imports, methods, or definitions are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets explicit minimal GitHub Actions permissions for the lint/format workflow.
> 
> - Adds `permissions: contents: write` under `jobs.lint_format` in `.github/workflows/lint-format.yml` to scope `GITHUB_TOKEN` appropriately while allowing commit/push of formatting changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cefcc89b3f00956d133d3a6a7bebe6b434dd226f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->