### PR TITLE
fix playlist page

### DIFF
--- a/src/routes/playlists/playlist/[slug]/+page.svelte
+++ b/src/routes/playlists/playlist/[slug]/+page.svelte
@@ -206,7 +206,7 @@
 				<img
 					src={imageUrl}
 					alt={playlist?.name}
-					class="mx-auto aspect-square w-full max-w-sm rounded-lg object-cover shadow-md md:mx-0"
+					class="aspect-square w-full max-w-sm rounded-lg object-cover shadow-md"
 				/>
 			{:catch}
 				<div


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts styling of the playlist image to align with the surrounding layout.
> 
> - Updates `+page.svelte` image classes by removing `mx-auto`/`md:mx-0`, preventing unintended centering and ensuring consistent alignment across breakpoints
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04140b4df431fabc59bcb81cc6263a56b39c88f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->